### PR TITLE
Color Editor use Color Input

### DIFF
--- a/resources/views/colors/create.blade.php
+++ b/resources/views/colors/create.blade.php
@@ -32,8 +32,8 @@
                     <textarea rows="5" columns="5" class="form-control" name="description"></textarea>
                 </div>
                 <div class="form-group">
-                    <label for="symptoms">Hex:</label>
-                    <input type="text" class="form-control" name="hex"/>
+                    <label for="symptoms">Color:</label>
+                    <input type="color" class="form-control" name="hex"/>
                 </div>
                 <button type="submit" class="btn btn-primary">Add Color</button>
             </form>

--- a/resources/views/colors/edit.blade.php
+++ b/resources/views/colors/edit.blade.php
@@ -30,8 +30,8 @@
                     <textarea rows="5" columns="5" class="form-control" name="description">{{ $color->description }}</textarea>
                 </div>
                 <div class="form-group">
-                    <label for="symptoms">Hex:</label>
-                    <input type="text" class="form-control" name="hex" value="{{ $color->hex }}"/>
+                    <label for="symptoms">Color:</label>
+                    <input type="color" class="form-control" name="hex" value="{{ $color->hex }}"/>
                 </div>
                 <button type="submit" class="btn btn-primary">Update Color</button>
             </form>


### PR DESCRIPTION
This one was subjective to me, but instead of typing out a HEX color code, I found it easier to use the color input itself as a better visual representation when I'm making or editing colors. Found it still saves it as a HEX value so it didnt break anything.

![Screen Shot 2020-07-30 at 7 40 18 PM](https://user-images.githubusercontent.com/37309201/88987750-81a49700-d29c-11ea-89fe-c77f05cf40e1.png)
