### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Admins can also create custom patterns with a built in codemirror textarea.
 This package comes with 3 models: basic settings, colors, and patterns. Run the following 
 
 ```
-composer require xpersonas/styleguide
+composer require xpersonas/laravel-styleguide
 php artisan vendor:publish --tag=xpersonas-styleguide
 php artisan migrate
 ```


### PR DESCRIPTION
I was getting the following on new installation of the package. Removed my `minimum-stability: 'dev'` line in my composer file and got the same error.

```
// composer require xpersonas/styleguide OR composer require 'xpersonas/styleguide:^1.0'
[InvalidArgumentException]                                                                                                                                                                                         
  Could not find a matching version of package xpersonas/styleguide. Check the package spelling, your version constraint and that the package is available in a stability which matches your minimum-stability (dev  
  ).  
```

---

Otherwise +1 for the Nova support WITH that awesome color editor